### PR TITLE
fix for #11: Allow inline newsletter signup

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -3501,3 +3501,9 @@ img.progicons {
 .site, #content, #page, .homeQuote {
   height: 100%;
 }
+
+
+.newsletterModal {
+  color: #333;
+  text-shadow:none;
+}

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ title: Code for Münster | codeformuenster.org
           <li class="navpeople"><a href="http://codefor.de/muenster/index.html#projects" target="_blank">Projekte</a></li>
          <form id="newsletterform" class="navbar-form pull-right" action="http://codeformuenster.us3.list-manage.com/subscribe/post?u=0280dca8af5c7f6308e1e36ae&amp;id=8151d48caa" method="post" class="validate" target="_blank" novalidate>
           <input type="email" name="EMAIL" class="span2" placeholder="john@doe.com">
-          <button type="submit" class="btn">Newsletter</button>
+          <button type="submit" name="subscribe" class="btn">Newsletter abonnieren</button>
          </form>
 
         </ul> <!-- nav -->

--- a/index.html
+++ b/index.html
@@ -21,7 +21,11 @@ title: Code for Münster | codeformuenster.org
           <li class="navpeople"><a href="https://github.com/codeformuenster/wersindwir" target="_blank">Über uns</a></li>
           <li class="navpeople"><a href="http://www.meetup.com/codeforde/Munster-DE/" target="_blank">Nächstes Treffen</a></li>
           <li class="navpeople"><a href="http://codefor.de/muenster/index.html#projects" target="_blank">Projekte</a></li>
-          <li class="navpeople"><a href="http://eepurl.com/OIlwT" target="_blank">Newsletter Anmeldung</a></li>
+         <form id="newsletterform" class="navbar-form pull-right" action="http://codeformuenster.us3.list-manage.com/subscribe/post?u=0280dca8af5c7f6308e1e36ae&amp;id=8151d48caa" method="post" class="validate" target="_blank" novalidate>
+          <input type="email" name="EMAIL" class="span2" placeholder="john@doe.com">
+          <button type="submit" class="btn">Newsletter</button>
+         </form>
+
         </ul> <!-- nav -->
       </div> <!-- collapse -->
     </div> <!-- container -->
@@ -47,5 +51,4 @@ title: Code for Münster | codeformuenster.org
   </div>
   {% endif %}
   {% endfor %}
-
 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -20,3 +20,32 @@ $(function(){
     }
   });
 });
+
+
+$(function(){
+$('#newsletterform').submit(function(e) {
+  var $this = $(this);
+  $.ajax({
+      type: "GET", // GET & url for json slightly different
+      url: "http://codeformuenster.us3.list-manage.com/subscribe/post-json?u=0280dca8af5c7f6308e1e36ae&id=8151d48caa&language=de&c=?",
+      data: $this.serialize(),
+      dataType    : 'json',
+      contentType: "application/json; charset=utf-8",
+      error       : function(err) { alert("Es konnte keine Verbindung hergestellt werden. Versuche es später nochmal."); },
+      success     : function(data) {
+          if (data.result != "success") {
+            $('#newsletterError').remove();
+            $('body').append('<div id="newsletterError" class="modal hide fade newsletterModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h4>Sorry</h4></div><div class="modal-body"><p>' + data.msg + '</p></div><div class="modal-footer"><button data-dismiss="modal" class="btn btn-primary">Schließen</button></div></div>');
+            $('#newsletterError').modal();
+          } else {
+            $('#newsletterform').fadeOut();
+            $('body').append('<div id="newsletterConfirm" class="modal hide fade newsletterModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h4>Nur noch ein Schritt</h4></div><div class="modal-body"><p>Vielen Dank für deine Anmeldung zum Newsletter. Um die Anmeldung zu bestätigen, klicke bitte auf den Link, den wir dir soeben zugeschickt haben.</p></div><div class="modal-footer"><button data-dismiss="modal" class="btn btn-primary">Schließen</button></div></div>');
+            $('#newsletterConfirm').modal();
+
+          }
+      }
+  });
+  return false;
+});
+
+});

--- a/js/main.js
+++ b/js/main.js
@@ -33,15 +33,14 @@ $('#newsletterform').submit(function(e) {
       contentType: "application/json; charset=utf-8",
       error       : function(err) { alert("Es konnte keine Verbindung hergestellt werden. Versuche es später nochmal."); },
       success     : function(data) {
-          if (data.result != "success") {
+          if (data.result == "success") {
+            $('body').append('<div id="newsletterConfirm" class="modal hide fade newsletterModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h4>Nur noch ein Schritt</h4></div><div class="modal-body"><p>Vielen Dank für deine Anmeldung zum Newsletter. Um die Anmeldung zu bestätigen, klicke bitte auf den Link, den wir dir soeben zugeschickt haben.</p></div><div class="modal-footer"><button data-dismiss="modal" class="btn btn-primary">Schließen</button></div></div>');
+            $('#newsletterConfirm').modal();
+            $('#newsletterform [name=EMAIL]').val('');
+          } else {
             $('#newsletterError').remove();
             $('body').append('<div id="newsletterError" class="modal hide fade newsletterModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h4>Sorry</h4></div><div class="modal-body"><p>' + data.msg + '</p></div><div class="modal-footer"><button data-dismiss="modal" class="btn btn-primary">Schließen</button></div></div>');
             $('#newsletterError').modal();
-          } else {
-            $('#newsletterform').fadeOut();
-            $('body').append('<div id="newsletterConfirm" class="modal hide fade newsletterModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button><h4>Nur noch ein Schritt</h4></div><div class="modal-body"><p>Vielen Dank für deine Anmeldung zum Newsletter. Um die Anmeldung zu bestätigen, klicke bitte auf den Link, den wir dir soeben zugeschickt haben.</p></div><div class="modal-footer"><button data-dismiss="modal" class="btn btn-primary">Schließen</button></div></div>');
-            $('#newsletterConfirm').modal();
-
           }
       }
   });


### PR DESCRIPTION
Allow inline signup for newsletter via mailchimp api. Signup and error messages are displayed in a bootstrap modal.
